### PR TITLE
V1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simplify and optimize your Socket communications with:
 
 **Requests per minute**
 
-<img src="http://i231.photobucket.com/albums/ee109/FeD135/perf_v110.png">
+<img src="http://i231.photobucket.com/albums/ee109/FeD135/perf_v120.png">
 
 *Benchmarks based on a single-thread queue test with Kalm default bundling settings*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kalm",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "The socket optimizer",
   "main": "./index.js",
   "scripts": {

--- a/src/Channel.js
+++ b/src/Channel.js
@@ -84,7 +84,7 @@ class Channel {
 	 */
 	_emit() {
 		if (this.packets.length > 0) {
-			this._emitter(this.name, this.packets);
+			this._emitter(this.name, this.packets.concat());
 			this.packets.length = 0;
 		}
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -37,7 +37,8 @@ class Server extends EventEmitter {
 			encoder: options.encoder || defaults.encoder,
 			port: options.port || defaults.port,
 			tick: options.tick || defaults.tick,
-			socketTimeout: options.socketTimeout || defaults.socketTimeout
+			socketTimeout: options.socketTimeout || defaults.socketTimeout,
+			rejectForeign: options.rejectForeign || defaults.rejectForeign
 		};
 
 		this.connections = [];

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -14,6 +14,7 @@ module.exports = {
 	stats: false,
 	tick: null,
 	socketTimeout: 1000 * 30,	// 30 seconds
+	rejectForeign: true,	// Destroys bad connection attempts
 	bundler: {
 		maxPackets: 2048,
 		serverTick: false,

--- a/tests/unit/Client.js
+++ b/tests/unit/Client.js
@@ -42,7 +42,8 @@ describe('Client', () => {
 				encoder: defaults.encoder,
 				bundler: defaults.bundler,
 				stats: defaults.stats,
-				socketTimeout: defaults.socketTimeout
+				socketTimeout: defaults.socketTimeout,
+				rejectForeign: defaults.rejectForeign
 			});
 			expect(result.channels).to.not.be.object;
 			expect(result.fromServer).to.be.false;
@@ -181,7 +182,7 @@ describe('Client', () => {
 	});
 
 	describe('#handleRequest(evt)', () => {
-		it('should call handleData on the appropriate channels', () => {
+		it('should call handleData on the appropriate channels', (done) => {
 			var testClient = new testModule({}, testSocket);
 			var testHandler1 = sinon.spy();
 			var testHandler2 = sinon.spy();
@@ -190,8 +191,11 @@ describe('Client', () => {
 
 			testClient.handleRequest(JSON.stringify(['test', ['data']]));
 
-			expect(testHandler1.withArgs('data').calledOnce).to.be.true;
-			expect(testHandler2.calledOnce).to.be.false;
+			setTimeout(() => {
+				expect(testHandler1.withArgs('data').calledOnce).to.be.true;
+				expect(testHandler2.calledOnce).to.be.false;
+				done();
+			},1);
 		});
 	});
 

--- a/tests/unit/Server.js
+++ b/tests/unit/Server.js
@@ -38,7 +38,8 @@ describe('Server', () => {
 				encoder: defaults.encoder,
 				port: defaults.port,
 				tick: defaults.tick,
-				socketTimeout: defaults.socketTimeout
+				socketTimeout: defaults.socketTimeout,
+				rejectForeign: defaults.rejectForeign
 			});
 			expect(testServer.connections).to.be.array;
 			expect(testServer.channels).to.be.object;
@@ -124,7 +125,8 @@ describe('Server', () => {
 					hostname: '0.0.0.0',
 					port: 3000,
 					socketTimeout: 30000,
-					stats: false
+					stats: false,
+					rejectForeign: true
 				}
 			]);
 		});
@@ -231,7 +233,8 @@ describe('Server', () => {
 						splitBatches: true
 					},
 					socketTimeout: 30000,
-					stats: false
+					stats: false,
+					rejectForeign: true
 				});
 				done();
 			});


### PR DESCRIPTION
## Performances
- Better throughput via Promisifying encoding process
## Async-ready Encoding
- Encoders can return either Promises or the straight result, Kalm will handle both. This allows for asynchronous encoding/decoding. #25 
## Auto-reject bad requests
- Added new `Client`/ `Server` option `rejectForeign` (default: `true`) to auto-disconnect bad/ unhandled requests 
